### PR TITLE
fix: MAGI review findings + CI/tooling cleanup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "docker"
+    directory: "/web"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ name: PlatformIO CI
 on:
   push:
     branches: [master, main]
+    tags: ['v*']
   pull_request:
     branches: [master, main]
 
@@ -29,9 +30,6 @@ jobs:
         run: pio test -e native_debug
 
   # Firmware build for every physical target
-  # (addresses T1 of the tech-debt audit: the previous workflow
-  #  did NOT compile any AVR target, so a refactor could silently
-  #  break production firmware)
   build-avr:
     name: Build ${{ matrix.env }}
     runs-on: ubuntu-latest
@@ -64,3 +62,22 @@ jobs:
             .pio/build/${{ matrix.env }}/firmware.elf
           if-no-files-found: error
           retention-days: 30
+
+  # Publish a GitHub Release with all firmware artifacts when a vX.Y.Z tag is pushed
+  release:
+    name: Release
+    needs: [test-native, build-avr]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all firmware artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: firmware
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: firmware/**/*
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TinySensor 
 
-[![Travis build status](https://api.travis-ci.org/arcadien/tinySensor.svg?branch=master)](https://travis-ci.org/arcadien/tinySensor)
+[![CI](https://github.com/arcadien/tinySensor/actions/workflows/main.yml/badge.svg)](https://github.com/arcadien/tinySensor/actions/workflows/main.yml)
 
 TinySensor aims to provide a customisable firmware and a hardware design for low-power environment sensors using wireless communication.
 

--- a/lib/hal/Attiny84aHal.cpp
+++ b/lib/hal/Attiny84aHal.cpp
@@ -47,11 +47,11 @@ static void UseLessPowerAsPossible() {
   ACSR |= _BV(ACD);
 
   // no timer1
-  PRR &= ~_BV(PRTIM1);
+  PRR |= _BV(PRTIM1);
 
   // no analog p. 129, 146, 131
   ADCSRA = 0;
-  PRR &= ~_BV(PRADC);
+  PRR |= _BV(PRADC);
 
   // better, but not easy to invert for VCC sensing
   DIDR0 |= _BV(ADC2D) | _BV(ADC1D); // digital buffers

--- a/lib/oregon/Oregon_v3.cpp
+++ b/lib/oregon/Oregon_v3.cpp
@@ -106,6 +106,7 @@ void OregonV3::SendZero() {
 }
 
 void OregonV3::SetChannel(uint8_t channel) {
+  if (channel < 1 || channel > 3) return;
   message[2] |= 1 << (4 + (channel - 1));
 }
 

--- a/lib/oregon/Oregon_v3.cpp
+++ b/lib/oregon/Oregon_v3.cpp
@@ -9,8 +9,6 @@
 #define PREAMBLE_BYTE2 0xFF
 #define PREAMBLE_BYTE3 0xFF
 
-uint8_t message[OregonV3::MESSAGE_SIZE_IN_BYTES];
-
 #define HALF_DELAY_US 512
 #define DELAY_US (HALF_DELAY_US * 2)
 #define PRESSURE_SCALING_VALUE 795

--- a/lib/oregon/Oregon_v3.cpp
+++ b/lib/oregon/Oregon_v3.cpp
@@ -71,15 +71,10 @@ void OregonV3::SendLSB(const uint8_t data) {
 
 int OregonV3::Sum(uint8_t count, const uint8_t *data) {
   int s = 0;
-
   for (uint8_t i = 0; i < count; ++i) {
     s += (data[i] & 0xF0) >> 4;
     s += (data[i] & 0xF);
   }
-
-  if (int(count) != count)
-    s += (data[count] & 0xF0) >> 4;
-
   return s;
 }
 

--- a/lib/oregon/Oregon_v3.h
+++ b/lib/oregon/Oregon_v3.h
@@ -93,6 +93,8 @@ private:
    */
   uint8_t messageStatus = 0;
 
+  uint8_t message[MESSAGE_SIZE_IN_BYTES];
+
   Hal *_hal;
 
   int Sum(uint8_t count, const uint8_t *data);

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,7 +1,9 @@
+[platformio]
+default_envs = S_02, S_03, S_04, S_05, robot, devmodule, SOLAR_TEST
+
 [env]
 extra_scripts = pre:shared/extra_script.py
-
-lib_compat_mode=off
+lib_compat_mode = off
 
 ; these libraries are for AVR and simulation
 ; targets only, so a reset of this property
@@ -12,9 +14,8 @@ lib_deps =
   unity=https://github.com/arcadien/Unity.git
   ds18b20=https://github.com/arcadien/avr-ds18b20.git
   bmx280=https://github.com/arcadien/SparkFun_BME280_Arduino_Library.git
-  ;ssd1306=https://github.com/lexus2k/ssd1306.git
 
-upload_protocol=custom
+upload_protocol = custom
 upload_flags =
     -Pusb
     -pt84
@@ -23,47 +24,39 @@ upload_flags =
     -b115200
     -B4
     -cavrisp2
-#    -cdragon_isp
-
-  #  -cavrispmkII
 upload_command = avrdude $UPLOAD_FLAGS -U flash:w:$SOURCE:i
 
-# upload_protocol=custom
-# upload_speed=115200
-# upload_flags=
-#   '-v'
-#   '-e'
-#   '-Pusb'
-#   '-B4'
-#   '-C/etc/avrdude.conf'
-#   '-pt84'
-#   '-cavrisp2'
-#   '-b115200'
+; ── Base environment shared by all physical ATtiny84a targets ─────────────────
+[env:avr_base]
+platform = atmelavr
+board = attiny84
+framework = arduino
+build_type = release
+board_build.f_cpu = 1000000L
+board_build.mcu = attiny84a
 
 [env:native_debug]
- lib_deps =
- platform=native
- build_type = debug
- debug_test = test_analogFiltering
- debug_build_flags = -O0 -ggdb3 -g3
- build_flags =
-   -DSENSOR_TYPE="{0xEA, 0x4C}"
-   -DSENSOR_ID=LacrosseWS7000::Address::ONE
-   -DOREGON_MODE_0=1
-   -DSLEEP_TIME_IN_SECONDS=32
-   -DNATIVE
-   -DBATTERY_VOLTAGE_X10_ID=0xA
+lib_deps =
+platform = native
+build_type = debug
+debug_test = test_analogFiltering
+debug_build_flags = -O0 -ggdb3 -g3
+build_flags =
+  -DSENSOR_TYPE="{0xEA, 0x4C}"
+  -DSENSOR_ID=LacrosseWS7000::Address::ONE
+  -DOREGON_MODE_0=1
+  -DSLEEP_TIME_IN_SECONDS=32
+  -DNATIVE
+  -DBATTERY_VOLTAGE_X10_ID=0xA
 
 [env:S_02]
-platform = atmelavr
-board= attiny84
-framework = arduino
-board_build.f_cpu = 1000000L
-board_build.mcu= attiny84a
-build_type = release
+extends = env:avr_base
 build_flags =
+  -D__AVR_ATtiny84__
+  -UARDUINO
+  -DAVR
   -DUSE_OREGON
-  -DOREGON_RCODE=0x20 # ID : 0210
+  -DOREGON_RCODE=0x20
   -DOREGON_CHANNEL=1
   -DUSE_BMP280=1
   -DINTERNAL_1v1=1100
@@ -71,61 +64,44 @@ build_flags =
   -DLOW_BATTERY_VOLTAGE=2200
   -DBATTERY_VOLTAGE_X10_ID=2
   -DUSE_CHARGE_PUMP=1
+
+[env:S_03]
+extends = env:avr_base
+build_flags =
   -D__AVR_ATtiny84__
   -UARDUINO
   -DAVR
-
-[env:S_03]
-platform = atmelavr
-board= attiny84
-framework = arduino
-board_build.f_cpu = 1000000L
-board_build.mcu= attiny84a
-build_type = release
-build_flags =
   -DUSE_LACROSSE
   -DLACROSSE_ID=LacrosseWS7000::Address::THREE
   -DUSE_BMP280=1
   -DINTERNAL_1v1=1101
-  -DUSE_BMP280=1
-  -DSLEEP_TIME_IN_SECONDS=300 
+  -DSLEEP_TIME_IN_SECONDS=300
   -DLOW_BATTERY_VOLTAGE=1100
   -DBATTERY_VOLTAGE_X10_ID=3
   -DUSE_CHARGE_PUMP=1
+
+[env:S_04]
+extends = env:avr_base
+build_flags =
   -D__AVR_ATtiny84__
   -UARDUINO
   -DAVR
-
-[env:S_04]
-platform = atmelavr
-board= attiny84
-framework = arduino
-build_type = release
-board_build.f_cpu = 1000000L
-board_build.mcu= attiny84a
-build_flags =
   -DUSE_OREGON
-  -DINTERNAL_1v1=1111l
   -DOREGON_RCODE=0x04
   -DOREGON_CHANNEL=1
   -DUSE_BME280=1
+  -DINTERNAL_1v1=1111l
   -DSLEEP_TIME_IN_SECONDS=300
   -DLOW_BATTERY_VOLTAGE=2200
   -DBATTERY_VOLTAGE_X10_ID=4
+
+; old HW design — 18650 powered
+[env:S_05]
+extends = env:avr_base
+build_flags =
   -D__AVR_ATtiny84__
   -UARDUINO
   -DAVR
-
-# old HW design
-# 18650 powered
-[env:S_05]
-platform = atmelavr
-board= attiny84
-framework = arduino
-build_type = release
-board_build.f_cpu = 1000000L
-board_build.mcu= attiny84a
-build_flags =
   -DSENSOR_ID=0x06
   -DSENSOR_CHANNEL=2
   -DOREGON_MODE=2
@@ -134,38 +110,26 @@ build_flags =
   -DSLEEP_TIME_IN_SECONDS=300
   -DLOW_BATTERY_VOLTAGE=3400
   -DBATTERY_VOLTAGE_X10_ID=5
+
+; Robot has been altered to have same HW interface as TinySensor.
+[env:robot]
+extends = env:avr_base
+build_flags =
+  -Os
   -D__AVR_ATtiny84__
   -UARDUINO
   -DAVR
-  
-# Robot has been altered to have 
-# same HW interface as TinySensor.
-# No 
-[env:robot]
-platform = atmelavr
-board= attiny84
-framework = arduino
-build_type = release
-board_build.f_cpu = 1000000L
-board_build.mcu= attiny84a
-build_flags =
-  -Os
   -DUSE_LACROSSE
   -DLACROSSE_ID=LacrosseWS7000::Address::THREE
-  #-DUSE_OREGON=TRUE
-  #-DOREGON_RCODE=0x06
-  #-DOREGON_CHANNEL=4
   -DSLEEP_TIME_IN_SECONDS=300
   -DUSE_BME280=1
   -DINTERNAL_1v1=1101l
   -DLOW_BATTERY_VOLTAGE=2200
   -DBATTERY_VOLTAGE_X10_ID=6
-  #-DUSE_SERIAL_LOG
-  -UARDUINO
-  -D__AVR_ATtiny84__
-  -DAVR
 
 [env:SOLAR_TEST]
+extends = env:avr_base
+build_type = debug
 platform_packages =
     platformio/tool-simavr
 test_speed = 9600
@@ -178,16 +142,11 @@ test_testing_command =
     -f
     1000000L
     ${platformio.build_dir}/${this.__env__}/firmware.elf
-platform = atmelavr
-board= attiny84
-framework = arduino
-# debug_build_flags = -O0 -ggdb3 -g3
-build_type = debug 
-board_build.f_cpu = 1000000L
-board_build.mcu= attiny84a
 build_flags =
   -Os
-  #-DUSE_BME280=1
+  -D__AVR_ATtiny84__
+  -UARDUINO
+  -DAVR
   -DINTERNAL_1v1=1092
   -DSLEEP_TIME_IN_SECONDS=300
   -DLOW_BATTERY_VOLTAGE=3300
@@ -196,38 +155,14 @@ build_flags =
   -DUSE_LACROSSE
   -DLACROSSE_ID=LacrosseWS7000::Address::TWO
   -DUSE_BH1750
-  -UARDUINO
-  -D__AVR_ATtiny84__
-  -DAVR
 
-# [env:cross]
-# platform = atmelavr
-# board= attiny84
-# framework = arduino
-# board_build.f_cpu = 1000000L
-# board_build.mcu= attiny84a
-# build_type = release
-# build_flags =
-#   -Wall
-#   -DSENSOR_ID=0x04
-#   -DOREGON_MODE=2
-#   -DUSE_BME280=1
-#   -DSLEEP_TIME_IN_SECONDS=900
-#   -DLOW_BATTERY_VOLTAGE=2200
-#   -DBATTERY_VOLTAGE_X10_ID=0x4c
-#   -D__AVR_ATtiny84__
-#   -UARDUINO
-
-# dev module
+; dev module
 [env:devmodule]
-platform = atmelavr
-board= attiny84
-framework = arduino
-# debug_build_flags = -O0 -ggdb3 -g3
-build_type = release
-board_build.f_cpu = 1000000L
-board_build.mcu= attiny84a
+extends = env:avr_base
 build_flags =
+  -D__AVR_ATtiny84__
+  -UARDUINO
+  -DAVR
   -DBATTERY_IS_VCC
   -DSENSOR_ID=LacrosseWS7000::Address::ONE
   -DUSE_BME280=1
@@ -235,6 +170,3 @@ build_flags =
   -DSLEEP_TIME_IN_SECONDS=300
   -DLOW_BATTERY_VOLTAGE=3300
   -DBATTERY_VOLTAGE_X10_ID=10
-  -D__AVR_ATtiny84__
-  -UARDUINO
-  -DAVR


### PR DESCRIPTION
## Summary

Fixes from the parallel MAGI review session, plus CI and tooling clean-up from the tech-debt audit.

### Code fixes (firmware)

- **fix: inverted PRR bit direction** (Attiny84aHal.cpp) - PRR was enabling Timer1 and ADC instead of powering them down; corrected to |=. Direct power waste on battery.
- **fix: SetChannel() out-of-range guard** (Oregon_v3.cpp) - channel > 3 shifted bits into the sensor ID nibbles, silently corrupting message[2].
- **fix: message[] moved from file-scope global to OregonV3 private member** - was an accidental singleton; two instances would have shared state.
- **fix: dead branch removed from OregonV3::Sum()** - copied from an internet source where count was float; with uint8_t the branch is always false.

### CI / tooling

- **platformio.ini**: introduced [env:avr_base] + extends to eliminate ~80% copy-paste across 7 physical environments; removed duplicate USE_BMP280=1 in env:S_03.
- **.github/dependabot.yml**: weekly updates for github-actions, monthly for docker and pip.
- **main.yml**: added release job triggered on v* tags - publishes firmware artifacts as GitHub Release.
- **README.md**: replaced dead Travis CI badge with live GitHub Actions badge.

## Test plan

- [ ] Native Unity test suite passes (pio test -e native_debug)
- [ ] All 7 AVR firmware environments build cleanly in CI matrix
- [ ] Dependabot PRs appear for stale Actions versions
- [ ] Pushing a v* tag triggers the release job and publishes .hex/.elf artifacts

Generated with Claude Code